### PR TITLE
fix the order of parameters as in the order they are documented in the code

### DIFF
--- a/commando/application.py
+++ b/commando/application.py
@@ -52,7 +52,7 @@ class Commando(type):
 
         def add_arguments(func):
             params = getattr(func, 'params', [])
-            for parameter in params:
+            for parameter in reversed(params):
                 func.parser.add_argument(*parameter.args, **parameter.kwargs)
 
         def add_subparser(func):


### PR DESCRIPTION
Hi,

can you take this fix, 
the order is impotent in the tools we are writing
(in the past we manually did it, I thought this code isn't maintained anymore)

but new I see there a new version (which broke our client code that was using our tools)

Israel
