### PR TITLE
Support both Python 2 and Python 3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ MANIFEST
 dist
 *egg*
 *gz
+.coverage
+.tox

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -31,6 +31,7 @@ Authors
 *   `Jon Banafato`_
 
     -   Upgrade from distribute to setuptools
+    -   Python 3 compatibility
 
 .. _Lakshmi Vyas: https://github.com/lakshmivyas
 .. _Brandon Philips: https://github.com/philips

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,7 @@ Version 0.3.5a
 --------------
 
 - Install with setuptools instead of distribute
+- Python 3 compatibility
 
 Version 0.3.4
 --------------

--- a/commando/_compat.py
+++ b/commando/_compat.py
@@ -1,0 +1,79 @@
+"""Python 2 and 3 compatibility module."""
+
+# Note: borrowed from https://github.com/dirn/Simon/
+
+import sys
+
+# Development should be done with Python 3 first. Rather than checking
+# for Python 3 and creating special cases for it, check for Python 2 and
+# create special cases for it instead.
+PY2 = sys.version_info[0] == 2
+
+if PY2:
+    # Define everything that is Python 2 specific.
+
+    # dictionary iterators
+    _iteritems = 'iteritems'
+    _iterkeys = 'iterkeys'
+    _itervalues = 'itervalues'
+
+    # other iterators
+    get_next = lambda x: x.next
+    range = xrange  # NOQA, Python 2 only
+
+    # types
+    str_types = (str, unicode)  # NOQA, Python 2 only
+
+    exec('def reraise(tp, value, tb=None):\n raise tp, value, tb')
+else:
+    # Define everything that is Python 3 specific.
+
+    # dictionary iterators
+    _iteritems = 'items'
+    _iterkeys = 'keys'
+    _itervalues = 'values'
+
+    # other iterators
+    get_next = lambda x: x.__next__
+    range = range
+
+    # types
+    str_types = (str,)
+
+    def reraise(tp, value, tb=None):
+        if getattr(value, '__traceback__', tb) is not tb:
+            raise value.with_traceback(tb)
+        raise value
+
+
+def iteritems(d, *args, **kwargs):
+    return iter(getattr(d, _iteritems)(*args, **kwargs))
+
+
+def iterkeys(d, *args, **kwargs):
+    return iter(getattr(d, _iterkeys)(*args, **kwargs))
+
+
+def itervalues(d, *args, **kwargs):
+    return iter(getattr(d, _itervalues)(*args, **kwargs))
+
+
+def with_metaclass(meta, *bases):
+    # This requires a bit of explanation: the basic idea is to make a
+    # dummy metaclass for one level of class instantiation that replaces
+    # itself with the actual metaclass.  Because of internal type checks
+    # we also need to make sure that we downgrade the custom metaclass
+    # for one level to something closer to type (that's why __call__ and
+    # __init__ comes back from type etc.).
+    #
+    # This has the advantage over six.with_metaclass in that it does not
+    # introduce dummy classes into the final MRO.
+    class metaclass(meta):
+        __call__ = type.__call__
+        __init__ = type.__init__
+
+        def __new__(cls, name, this_bases, d):
+            if this_bases is None:
+                return type.__new__(cls, name, (), d)
+            return meta(name, bases, d)
+    return metaclass('DummyMetaClass', None, {})

--- a/commando/application.py
+++ b/commando/application.py
@@ -5,6 +5,7 @@ Declarative interface for argparse
 from argparse import ArgumentParser
 from collections import namedtuple
 from commando.util import getLoggerWithConsoleHandler
+from ._compat import itervalues, with_metaclass
 
 import logging
 import sys
@@ -46,7 +47,7 @@ class Commando(type):
         main_parser = None
         # pylint: disable-msg=C0111
         # Collect commands based on decorators
-        for member in attrs.itervalues():
+        for member in itervalues(attrs):
             if hasattr(member, "command"):
                 main_command = member
             elif hasattr(member, "subcommand"):
@@ -227,11 +228,10 @@ class append_const(param):
                                                 **kwargs)
 
 
-class Application(object):
+class Application(with_metaclass(Commando, object)):
     """
     Barebones base class for command line applications.
     """
-    __metaclass__ = Commando
 
     def __init__(self, raise_exceptions=False, logger=None):
         self.raise_exceptions = raise_exceptions
@@ -305,7 +305,7 @@ class Application(object):
                 args.run(self, args)
             else:
                 self.__main__(args) # pylint: disable-msg=E1101
-        except Exception, e: # pylint: disable-msg=W0703
+        except Exception as e: # pylint: disable-msg=W0703
             import traceback
             self.logger.debug(traceback.format_exc())
             self.logger.error(e.message)

--- a/commando/application.py
+++ b/commando/application.py
@@ -308,7 +308,7 @@ class Application(with_metaclass(Commando, object)):
         except Exception as e: # pylint: disable-msg=W0703
             import traceback
             self.logger.debug(traceback.format_exc())
-            self.logger.error(e.message)
+            self.logger.error(str(e))
             if self.raise_exceptions:
                 raise
             sys.exit(2)

--- a/commando/conf.py
+++ b/commando/conf.py
@@ -5,6 +5,8 @@ configuration objects.
 
 from collections import defaultdict
 
+from ._compat import with_metaclass, iteritems
+
 SEQS = (tuple, list, set, frozenset)
 
 class ConfigDict(defaultdict):
@@ -16,7 +18,7 @@ class ConfigDict(defaultdict):
     def __init__(self, initial=None):
         super(ConfigDict, self).__init__(ConfigDict)
         initial = initial or {}
-        for key, value in initial.iteritems():
+        for key, value in iteritems(initial):
             self.__setitem__(key, value)
 
     def __setitem__(self, key, value):
@@ -71,7 +73,7 @@ class ConfigDict(defaultdict):
 
         """
         overrides = overrides or {}
-        for key, value in overrides.iteritems():
+        for key, value in iteritems(overrides):
             current = self.get(key)
             if isinstance(value, dict) and isinstance(current, dict):
                 current.patch(value)
@@ -113,15 +115,15 @@ class AutoPropMetaClass(type):
     """
     def __new__(mcs, cname, cbases, cattrs):
         autoprops = {name: member
-                        for name, member in cattrs.iteritems()
+                        for name, member in iteritems(cattrs)
                         if getattr(member, 'autoprop', False)}
-        for name, member in autoprops.iteritems():
+        for name, member in iteritems(autoprops):
             cattrs[name] = AutoPropDescriptor(member)
         return super(AutoPropMetaClass, mcs).__new__(
                 mcs, cname, cbases, cattrs)
 
 # pylint: disable-msg=R0903
-class AutoProp(object):
+class AutoProp(with_metaclass(AutoPropMetaClass, object)):
     """
     The base class for all objects supporting autoprops.
 
@@ -144,7 +146,6 @@ class AutoProp(object):
     >>> 'xyz'
 
     """
-    __metaclass__ = AutoPropMetaClass
 
     @staticmethod
     def default(function):

--- a/commando/tests/test_commando.py
+++ b/commando/tests/test_commando.py
@@ -180,7 +180,7 @@ def test_command_subcommands_usage():
     with patch.object(ComplexCommandLine, '_main'):
         with patch.object(ComplexCommandLine, '_sub'):
             c = ComplexCommandLine()
-            c.parse(['--usage'])
+            c.parse(['--help'])
 
 
 @trap_exit_fail
@@ -198,7 +198,7 @@ class EmptyCommandLine(Application):
 
     @command(description='test', prog='Empty')
     def main(self, params):
-        assert params == []
+        assert not params.__dict__
         self._main()
 
     @subcommand('sub', description='test sub')

--- a/commando/tests/test_commando.py
+++ b/commando/tests/test_commando.py
@@ -6,17 +6,8 @@ Use nose
 `$ nosetests test_commando.py -d -v`
 """
 
-from contextlib import nested
 from commando import *
 from mock import patch
-
-
-try:
-    import cStringIO
-    StringIO = cStringIO
-except ImportError:
-    import StringIO as xStringIO
-    StringIO = xStringIO
 
 
 def trap_exit_fail(f):
@@ -25,7 +16,7 @@ def trap_exit_fail(f):
             f(*args)
         except SystemExit:
             import traceback
-            print traceback.format_exc()
+            print (traceback.format_exc())
             assert False
     test_wrapper.__name__ = f.__name__
     return test_wrapper
@@ -34,7 +25,7 @@ def trap_exit_fail(f):
 def trap_exit_pass(f):
     def test_wrapper(*args):
         try:
-            print f.__name__
+            print (f.__name__)
             f(*args)
         except SystemExit:
             pass
@@ -186,21 +177,21 @@ class ComplexCommandLine(Application):
 
 @trap_exit_pass
 def test_command_subcommands_usage():
-    with nested(patch.object(ComplexCommandLine, '_main'),
-                patch.object(ComplexCommandLine, '_sub')) as (_main, _sub):
-        c = ComplexCommandLine()
-        c.parse(['--usage'])
+    with patch.object(ComplexCommandLine, '_main'):
+        with patch.object(ComplexCommandLine, '_sub'):
+            c = ComplexCommandLine()
+            c.parse(['--usage'])
 
 
 @trap_exit_fail
 def test_command_subcommands():
-    with nested(patch.object(ComplexCommandLine, '_main'),
-                patch.object(ComplexCommandLine, '_sub')) as (_main, _sub):
-        c = ComplexCommandLine()
-        args = c.parse(['sub', '--launch', '--launch2', 'True'])
-        c.run(args)
-        assert not _main.called
-        assert _sub.call_count == 1
+    with patch.object(ComplexCommandLine, '_main') as _main:
+        with patch.object(ComplexCommandLine, '_sub') as _sub:
+            c = ComplexCommandLine()
+            args = c.parse(['sub', '--launch', '--launch2', 'True'])
+            c.run(args)
+            assert not _main.called
+            assert _sub.call_count == 1
 
 
 class EmptyCommandLine(Application):
@@ -225,22 +216,22 @@ class EmptyCommandLine(Application):
 
 @trap_exit_pass
 def test_empty_main_command():
-    with nested(patch.object(EmptyCommandLine, '_main'),
-                patch.object(EmptyCommandLine, '_sub')) as (_main, _sub):
-        e = EmptyCommandLine(raise_exceptions=True)
-        args = e.parse(None)
-        e.run(args)
-        assert not _sub.called
-        assert _main.call_count == 1
+    with patch.object(EmptyCommandLine, '_main') as _main:
+        with patch.object(EmptyCommandLine, '_sub') as _sub:
+            e = EmptyCommandLine(raise_exceptions=True)
+            args = e.parse(None)
+            e.run(args)
+            assert not _sub.called
+            assert _main.call_count == 1
 
 
 def test_empty_sub_command():
-    with nested(patch.object(EmptyCommandLine, '_main'),
-                patch.object(EmptyCommandLine, '_sub')) as (_main, _sub):
-        e = EmptyCommandLine(raise_exceptions=True)
-        e.run(e.parse(['sub']))
-        assert not _main.called
-        assert _sub.call_count == 1
+    with patch.object(EmptyCommandLine, '_main') as _main:
+        with patch.object(EmptyCommandLine, '_sub') as _sub:
+            e = EmptyCommandLine(raise_exceptions=True)
+            e.run(e.parse(['sub']))
+            assert not _main.called
+            assert _sub.call_count == 1
 
 
 class NestedCommandLine(Application):
@@ -293,11 +284,10 @@ class NestedCommandLine(Application):
 
 @trap_exit_fail
 def test_nested_command_subcommands():
-    with nested(patch.object(NestedCommandLine, '_main'),
-                patch.object(NestedCommandLine, '_sub'),
-                patch.object(NestedCommandLine, '_foobar_bla'),
-                patch.object(NestedCommandLine, '_foobar_blip_blop')) \
-                as (_main, _sub, _foobar_bla, _foobar_blip_blop):
+    with patch.object(NestedCommandLine, '_main') as _main, \
+         patch.object(NestedCommandLine, '_sub') as _sub, \
+         patch.object(NestedCommandLine, '_foobar_bla') as _foobar_bla, \
+         patch.object(NestedCommandLine, '_foobar_blip_blop') as _foobar_blip_blop:
 
         c = NestedCommandLine(raise_exceptions=True)
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,14 @@
+[tox]
+envlist = py27,py33,py34
+
+[testenv]
+deps =
+    coverage
+    fswrap
+    markdown
+    mock
+    nose
+    pyyaml
+commands =
+    python -m coverage run -m nose
+    python -m coverage report -m --include="commando/*.py"


### PR DESCRIPTION
The quest for Hyde<sup>3</sup> continues!

- Add a _compat module to handle several differences including usage of
  metaclasses and iter* methods on dictionaries
- Remove usage of contextlib.nested
- Make print work as both a function and a statement
- tox.ini is added to support testing under multiple versions of Python

Fixes #14, (in combination with #15) fixes #12

Note: Depends on #15 and lakshmivyas/fswrap#3