### PR TITLE
Correct version in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
     description='A declarative interface to argparse with additional utilities',
     long_description=long_description,
 
-    version='0.3.4',
+    version='0.3.5a',
 
     author='Lakshmi Vyas',
     author_email='lakshmi.vyas@gmail.com',


### PR DESCRIPTION
During the update to 0.3.5a, the version information in setup.py was
mistakenly left at 0.3.4. This change synchronizes version info.